### PR TITLE
Make `-vm` SSH mode work end-to-end; add Slurm-aware `encap tail` and `-fp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ encap rerun scripts/my_script.py -n test
 ```
 This command re-runs the experiment without copying the script again. This is useful if you want to re-run an old experiment with different parameters. For instance, you can copy the script (using the copy command), modify the parameters, and then rerun the updated script.
 
+## Following an Experiment with `encap tail`
+
+If you started an experiment in another shell, or detached from a remote `-vm` run while the job is still going on the cluster, you can re-attach to its log later:
+```bash
+encap tail scripts/my_script.py -n test
+```
+This streams the log in real time and exits cleanly when the experiment finishes — either when the script writes its end-of-transmission marker on normal exit, or, for Slurm jobs, when the job leaves the queue (so `scancel`, walltime kills, and OOMs are detected too). For experiments that have already completed, the full log is dumped once and `encap tail` returns.
+
+Combine with `-vm <machine_name>` to follow a remote job.
+
 ## Running Multiple Experiments in Parallel
 
 #### my_script.py
@@ -232,13 +242,19 @@ If you often forget to commit your changes before performing a simulation, you c
 git-track-force: <repo_dir_3>
 ```
 
-## Configuring SSH (untested with newest features)
+## Configuring SSH
 
-You can execute scripts on a remote server through SSH. To do this, a mirror of the local folder is created on the remote server.
-
+You can execute scripts on a remote server through SSH. Encap mirrors the project folder on the remote, runs the experiment there, and pulls results back when it finishes — all in a single command.
 ```bash
-encap run scripts/my_script.py -name <version_name> -vm <machine_name>
+encap run scripts/my_script.py -n <version_name> -vm <machine_name>
 ```
+The same `-vm` flag works with `rerun` and `tail`. It can be combined with the Slurm flags to submit a Slurm job on the remote in one step.
+
+Transfers in both directions use `rsync`, so only changed files cross the network and mtimes are preserved. If you ever need to bypass the change-detection (for example after a clock-skew incident on the remote), use `-fp` / `--force-push` to transfer regardless of timestamps:
+```bash
+encap run scripts/my_script.py -n <version_name> -vm <machine_name> -fp
+```
+
 The configuration file is located at `~/.encap/config.yml`:
 ```yml
 file_extension:
@@ -258,10 +274,14 @@ projects:
 ssh_ignore: ["X11 forwarding request failed on channel"]
 ```
 
-### Ignore folders while rsyncing between local and remote machine
+### Excluding files from rsync
+
+Push (local → remote) and pull (remote → local) have separate exclude lists, since they usually have opposite intent.
 ```yml
-rsync_exclude: [".git", "*log*"]
+rsync_exclude_push: [".git", "__pycache__", "*.hdf5"]   # don't ship up
+rsync_exclude_pull: ["__pycache__"]                       # don't bring back
 ```
+The legacy single `rsync_exclude` key is still accepted and is treated as an alias for `rsync_exclude_push`.
 
 ## Configuring Google Cloud
 TODO

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Encap: A Simple Tool for Managing Computational Experiments
+
 <p align="center">
 <img src="https://user-images.githubusercontent.com/53435922/217352989-c400e86c-31e0-40cb-a734-004e5994dda8.svg" width="200"/>
 </p>
@@ -9,28 +10,34 @@ Encap is a user-friendly tool designed to help you manage and keep track of your
 
 Encap currently supports:
 
-* Re-running old experiments
-* Tracking git repositories
-* Running multiple experiments in parallel
-* Running experiments on Slurm
-* Running experiments remotely via SSH
+- Re-running old experiments
+- Tracking git repositories
+- Running multiple experiments in parallel
+- Running experiments on Slurm
+- Running experiments remotely via SSH
 
 Note that Encap is currently only compatible with Linux/macOS.
 
 ## Running a Script with Encap
 
 Instead of running a script using the standard command:
+
 ```bash
 python scripts/my_script.py
 ```
+
 You can run it with Encap by typing:
+
 ```
 encap run scripts/my_script.py -n <version_name>
 ```
+
 This command creates a folder named `scripts/my_script/<version_name>` and copies the script inside. The script is then automatically executed using the following command:
+
 ```
 setsid nohup time python scripts/my_script/<version_name>/my_script.py &>> scripts/my_script/<version_name>/log & disown
 ```
+
 As the experiment runs, the log file is displayed in the terminal, making it easy and convenient to monitor different computing experiments.
 
 ### Python Example
@@ -38,6 +45,7 @@ As the experiment runs, the log file is displayed in the terminal, making it eas
 Consider the following simple Python experiment:
 
 #### my_script.py
+
 ```python
 import pickle
 
@@ -50,30 +58,39 @@ data = ["Some", "test", "data"]
 # Save the data
 pickle.dump(data, open(save_name, "wb"))
 ```
+
 By running:
+
 ```
 encap run scripts/my_script.py -n test
 ```
+
 You'll get the output:
+
 ```
 PID 23968
 Sat Sep 14 01:03:28 CEST 2019
-scripts/test/my_script.py   
+scripts/test/my_script.py
 
 test_data.p
 ```
+
 And the following three files will be generated:
-* my_script/test/log
-* my_script/test/my_script.py
-* my_script/test/test_data.p
+
+- my_script/test/log
+- my_script/test/my_script.py
+- my_script/test/test_data.p
 
 ## Installation
+
 To install Encap, use the following command:
+
 ```bash
 pip install encap
 ```
 
 ## Accessing Help
+
 ```bash
 encap -h
 ```
@@ -81,17 +98,21 @@ encap -h
 ## Re-running a Previous Experiment
 
 To re-run a previous experiment, use Encap in rerun mode:
+
 ```bash
 encap rerun scripts/my_script.py -n test
 ```
+
 This command re-runs the experiment without copying the script again. This is useful if you want to re-run an old experiment with different parameters. For instance, you can copy the script (using the copy command), modify the parameters, and then rerun the updated script.
 
 ## Following an Experiment with `encap tail`
 
 If you started an experiment in another shell, or detached from a remote `-vm` run while the job is still going on the cluster, you can re-attach to its log later:
+
 ```bash
 encap tail scripts/my_script.py -n test
 ```
+
 This streams the log in real time and exits cleanly when the experiment finishes — either when the script writes its end-of-transmission marker on normal exit, or, for Slurm jobs, when the job leaves the queue (so `scancel`, walltime kills, and OOMs are detected too). For experiments that have already completed, the full log is dumped once and `encap tail` returns.
 
 Combine with `-vm <machine_name>` to follow a remote job.
@@ -99,6 +120,7 @@ Combine with `-vm <machine_name>` to follow a remote job.
 ## Running Multiple Experiments in Parallel
 
 #### my_script.py
+
 ```python
 import pickle
 import os
@@ -110,21 +132,25 @@ print("This is the", i, "encap instance")
 
 pickle.dump(["Some", "test", "data", i], open(save_name, "wb"))
 ```
+
 To run the script three times in parallel, use the following command:
+
 ```bash
 encap run scripts/my_script.py -i 3 -n test
 ```
-This command generates the following files:
-* my_script/test/my_script.py
-* my_script/test/log
-* my_script/test/log_1
-* my_script/test/log_2
-* my_script/test/test_data_0.p
-* my_script/test/test_data_1.p
-* my_script/test/test_data_2.p
 
+This command generates the following files:
+
+- my_script/test/my_script.py
+- my_script/test/log
+- my_script/test/log_1
+- my_script/test/log_2
+- my_script/test/test_data_0.p
+- my_script/test/test_data_1.p
+- my_script/test/test_data_2.p
 
 ## More Examples
+
 Several examples can be found in the examples folder.
 
 You can find more examples in the `examples` folder.
@@ -134,49 +160,66 @@ You can find more examples in the `examples` folder.
 There are three ways to choose the interpreter for executing your script:
 
 1. Set a custom file extension in the configuration file located in `~/.encap/config.yml` (see Sec. Nested Configurations)
+
 ```yml
 file_extension:
   go: go run
 ```
+
 2. Make your script executable, which will execute it directly.
 3. Pass your desired interpreter as a command-line argument:
+
 ```sh
 encap run my_script.go -n <version> --interpreter "go run"
 ```
 
 ## Archive Mode - tar/untar
+
 To tar an experiment, use the following command:
+
 ```bash
 encap tar scripts/my_script.py -n test
 ```
+
 This command creates a tar.gz file of the experiment folder and saves it. To untar the experiment, use the following command:
+
 ```bash
 encap untar scripts/my_script.py -n test
 ```
+
 If all experiments should be tarred remove the `-n` argument.
+
 ```bash
 encap untar scripts/my_script.py
 ```
+
 ## Configuring Slurm
 
 Encap can also work with Slurm. To run your experiment using Slurm, execute the following command:
+
 ```
 encap run slurm_test.py -n test -sl
 ```
+
 If you want to run three experiments in parallel, use this command:
+
 ```
 encap run slurm_test.py -n test -sl_i 3
 ```
+
 This command launches three different Slurm jobs and passes the `ENCAP_PROCID` environment variable to the script. In this example, the `ENCAP_PROCID` will take the values 0, 1, 2 if ntasks-per-node has been configured to be one. If you run:
+
 ```sh
 encap run slurm_test.py -n test -sl_i 3 -sl_ntasks 20
 ```
+
 60 jobs will be launched in total, and the `ENCAP_PROCID` will take the values 0-59 respectively.
 See `/examples/slurm_test.py` for more details.
 
 The configuration file is located at `~/.encap/config.yml`.
 
 Example config file for a Slurm job:
+
 ```yml
 file_extension:
   py: python -u
@@ -189,10 +232,12 @@ slurm:
   time: "24:00:00" # Time until your job is terminated by Slurm
 ```
 
-If you want to execute different Slurm instances in parallel, use the `-sl_i <i>` argument. This will create *i* different Slurm jobs.
+If you want to execute different Slurm instances in parallel, use the `-sl_i <i>` argument. This will create _i_ different Slurm jobs.
 
 ### Adavnced Configurations
+
 You can create custom code to be executed within the Slurm file. For example, you may need to restart a Slurm job if it doesn't complete successfully within the allowed time. Here's a sample configuration file that restarts the Slurm job up to two additional times if it fails to complete:
+
 ```yml
 slurm:
   account: <account>
@@ -207,6 +252,7 @@ slurm:
     - sbatch {run.slurm}
     - fi
 ```
+
 This configuration is useful if your job needs to run for longer than the maximum time allowed by your Slurm system. The job will be run up to three times in total, including two restarts, and it is up to you to save and reload the current state of your computational experiment.
 
 In this example, `{run.sh}` and `{run.slurm}` will be replaced by encap with the actual script and Slurm file automatically upon execution.
@@ -218,9 +264,11 @@ Sometimes you may want to have different configuration files for different proje
 ## Folder Mode
 
 If you need to run a script that relies on other files within the same folder, you can use the folder mode. This mode duplicates the entire folder into the experiment folder and then runs the main script. This is particularly helpful if you have a custom .encap.conf file in the folder that you want to use for the experiment or if your script depends on a configuration file located in the same folder. The folder mode is automatically activated if you provide a folder instead of a script to Encap. For example:
+
 ```bash
 encap run examples/folder_script -n test
 ```
+
 This command will copy the entire folder to the experiment folder and then execute the script called `run.*` in the folder.
 
 Note that the script name can be different from `run.*` if it is specified with the `-f` argument, or if the folder contains a `.encap.conf` file with the `script_name` field set to the name of the script.
@@ -228,16 +276,19 @@ Note that the script name can be different from `run.*` if it is specified with 
 ## Tracking Git Repositories
 
 If you want to keep track of the commit in a git repository, add the following to your `.encap.conf` file:
+
 ```yml
 git-track:
   - <repo_dir_1>
   - <repo_dir_2>
 ```
+
 This configuration will write the commit hash of the current commit in the repository to the `.encap_history.conf` file in the experiment folder. This can be helpful if you want to keep track of the exact commit used for a specific experiment, in case you need to reproduce the results in the future.
 
 ## Force Commit Changes to Git (experimental)
 
 If you often forget to commit your changes before performing a simulation, you can use `git-track-force`. This feature creates a new branch called `encap`. The `encap` branch is always automatically kept up to date with the current state of your git project. This is done by committing any changes on the `encap` branch and saving the hash of this commit in your experiment folder. This process ensures that you can always go back to the moment in time when you performed the experiment. Note that this procedure uses worktrees to ensure that your main branch remains untouched.
+
 ```yml
 git-track-force: <repo_dir_3>
 ```
@@ -245,31 +296,37 @@ git-track-force: <repo_dir_3>
 ## Configuring SSH
 
 You can execute scripts on a remote server through SSH. Encap mirrors the project folder on the remote, runs the experiment there, and pulls results back when it finishes — all in a single command.
+
 ```bash
 encap run scripts/my_script.py -n <version_name> -vm <machine_name>
 ```
+
 The same `-vm` flag works with `rerun` and `tail`. It can be combined with the Slurm flags to submit a Slurm job on the remote in one step.
 
 Transfers in both directions use `rsync`, so only changed files cross the network and mtimes are preserved. If you ever need to bypass the change-detection (for example after a clock-skew incident on the remote), use `-fp` / `--force-push` to transfer regardless of timestamps:
+
 ```bash
 encap run scripts/my_script.py -n <version_name> -vm <machine_name> -fp
 ```
 
 The configuration file is located at `~/.encap/config.yml`:
+
 ```yml
 file_extension:
   py: python -u
   sh: bash
 
 projects:
-   <dir_in_local_machine>:
+  <dir_in_local_machine>:
     dir: <dir_in_remote_machine>
     ssh:
       user: <username>
       <machine_name>:
         ip: <ip>
 ```
+
 ### Ignore SSH output
+
 ```yml
 ssh_ignore: ["X11 forwarding request failed on channel"]
 ```
@@ -277,13 +334,16 @@ ssh_ignore: ["X11 forwarding request failed on channel"]
 ### Excluding files from rsync
 
 Push (local → remote) and pull (remote → local) have separate exclude lists, since they usually have opposite intent.
+
 ```yml
-rsync_exclude_push: [".git", "__pycache__", "*.hdf5"]   # don't ship up
-rsync_exclude_pull: ["__pycache__"]                       # don't bring back
+rsync_exclude_push: [".git", "__pycache__", "*.hdf5"] # don't ship up
+rsync_exclude_pull: ["__pycache__"] # don't bring back
 ```
+
 The legacy single `rsync_exclude` key is still accepted and is treated as an alias for `rsync_exclude_push`.
 
 ## Configuring Google Cloud
+
 TODO
 
 That's an overview of the main features and configurations for the Encap tool. You can use it to efficiently manage your computational experiments and ensure that your results are reproducible. If you have any questions, or want to contribute to the project, feel free to leave an issue.

--- a/encap
+++ b/encap
@@ -18,19 +18,67 @@ from encap_lib.status import get_status, print_status
 import encap_lib.git_tracker as git_tracker
 
 def tail_pull(machine, run_folder_name, pid=None, log_file_name="log"):
-    if pid is not None and platform.system() != "Darwin":
+    # `pid` can be:
+    #   - None                       no tracked process, fall back to EOT loop
+    #   - "<digits>"                 OS PID on the remote (non-slurm run)
+    #   - "slurm:<jobid>"            slurm job id (set by run_slurm so encap
+    #                                tail can poll squeue)
+    is_slurm = isinstance(pid, str) and pid.startswith("slurm:")
+    is_os_pid = isinstance(pid, str) and pid.isdigit()
+
+    if is_slurm:
+        # Stream the log AND poll squeue. Exits on either the EOT marker
+        # (normal completion) or when the slurm job leaves the queue (catches
+        # scancel, walltime cap, OOM kill, etc.). `-n +1` so we dump the full
+        # log on attach, matching the --pid branch below.
+        jobid = pid.split(":", 1)[1]
+        machine.run_code(f"""#!/bin/bash
+touch {run_folder_name}/{log_file_name}
+exec 3< <(tail -f -n +1 {run_folder_name}/{log_file_name})
+TAIL_PID=$!
+trap 'kill $TAIL_PID 2>/dev/null; wait $TAIL_PID 2>/dev/null' EXIT
+
+while true; do
+    # Drain currently-available log lines (1s timeout per blocked read).
+    while IFS= read -r -t 1 -u 3 LOGLINE; do
+        [[ "$LOGLINE" == "{chr(4)}" ]] && exit 0
+        printf '%s\\n' "$LOGLINE"
+    done
+    # No log activity for >=1s -- check whether the slurm job is still queued/running.
+    if ! squeue -h -j {jobid} 2>/dev/null | grep -q .; then
+        # Job is gone. Final drain to catch any last buffered lines, then exit.
+        while IFS= read -r -t 1 -u 3 LOGLINE; do
+            [[ "$LOGLINE" == "{chr(4)}" ]] && exit 0
+            printf '%s\\n' "$LOGLINE"
+        done
+        exit 0
+    fi
+done
+""", verbose=True, output=True)
+        machine.run_code(f"rm {run_folder_name}/pid -f")
+    elif is_os_pid and platform.system() != "Darwin":
         machine.run_code(f"touch {run_folder_name}/{log_file_name}; tail -f -n +1 --pid={pid} -f {run_folder_name}/{log_file_name}", verbose=True, output=True)
         machine.run_code(f"rm {run_folder_name}/pid -f")
     else:
-        # Runs the tail command until it sees the special character
+        # Runs the tail command until it sees the special character.
+        # `tail -f` is wired through an explicit FD so its PID is captured in
+        # $! and killed on EXIT -- otherwise, when the loop exits on EOT,
+        # tail keeps sitting in its inotify/kqueue wait and only learns the
+        # reader is gone the next time it tries to write. If the script emits
+        # nothing after EOT (no atexit / no stderr flush), tail hangs forever,
+        # ssh keeps the session up, and encap appears frozen until Ctrl-C.
+        # `-n +1` so already-finished logs are dumped fully on attach.
         machine.run_code(f"""#!/bin/bash
 touch {run_folder_name}/{log_file_name}
-while IFS= read -r LOGLINE || [[ -n "$LOGLINE" ]]; do
+exec 3< <(tail -f -n +1 {run_folder_name}/{log_file_name})
+TAIL_PID=$!
+trap 'kill $TAIL_PID 2>/dev/null; wait $TAIL_PID 2>/dev/null' EXIT
+while IFS= read -r -u 3 LOGLINE || [[ -n "$LOGLINE" ]]; do
     [[ "${{LOGLINE}}" == "{chr(4)}" ]] && exit 0
     printf '%s\\n' "$LOGLINE"
-done < <(tail -f {run_folder_name}/{log_file_name})
+done
 """, verbose=True, output=True)
-    
+
     machine.pull(run_folder_name, run_folder_name, directory=True)
 
 
@@ -78,7 +126,14 @@ def run(machine, file_extension, args, run_folder_name, target_file, target_file
     """
     Run the file and save outputs in log, save PID in the file pid.
     """
-    machine.push(target_file_path, target_file_path, directory=False, verbose=True)
+    # The right file is already on the remote by the time we get here:
+    #   - folder-mode fresh-run: source pushed via rsync_push in mode_run_folder
+    #   - file-mode fresh-run:   source pushed via mode_run_file's push
+    #   - rerun:                 pushed via the `if rerun:` rsync_push in mode_rerun_file
+    # An additional self-push here would, for -vm runs where the local
+    # 0encap_folder copy is a stale pull-back from a previous run, overwrite
+    # the freshly-pushed remote file with that stale copy, silently
+    # discarding the user's source edits.
 
     # Check if the files is executable, if yes then run it directly
     is_executable = os.access(target_file_path, os.X_OK)
@@ -152,7 +207,7 @@ def run(machine, file_extension, args, run_folder_name, target_file, target_file
     return pids[0], log_file_names[0]
 
 def run_slurm(machine, file_extension, target, args, run_folder_name, target_file, target_file_path, slurm_settings, interpreter_args="", name=None):
-    machine.push(target_file_path, target_file_path, directory=False, verbose=True)
+    # (Redundant self-push removed -- see comment in run() above.)
 
     # Delete previous log file and create a new one
     machine.run_code(f"""rm {run_folder_name}/pid -f
@@ -172,6 +227,11 @@ def run_slurm(machine, file_extension, target, args, run_folder_name, target_fil
         iterator = slurm_settings["i"]
     
     log_file_name = ""
+    # Capture the first instance's slurm job id and persist it as
+    # `slurm:<id>` in the pid file so `encap tail` can poll squeue and detect
+    # both normal completion (EOT marker in log) and abnormal terminations
+    # (scancel, walltime cap, OOM kill -- where no EOT is ever written).
+    first_slurm_jobid = None
     # Create the slurm script for all slurm instances
     for i in iterator:
         if i == 0:
@@ -217,7 +277,22 @@ def run_slurm(machine, file_extension, target, args, run_folder_name, target_fil
         if "sbatch: command not found" in out[0]:
             print("Error: Slurm does not seem to be installed on this machine.")
             exit(1)
-    return log_file_name
+
+        # Extract the slurm job id from sbatch's output ("Submitted batch job
+        # 12345") and persist the first instance's id as "slurm:<id>" in the
+        # pid file. tail_pull uses this to poll squeue.
+        if i == 0:
+            for line in out:
+                parts = line.strip().split()
+                if parts and parts[-1].isdigit():
+                    first_slurm_jobid = parts[-1]
+                    break
+            if first_slurm_jobid is not None:
+                machine.run_code(
+                    f"echo 'slurm:{first_slurm_jobid}' > {run_folder_name}/pid"
+                )
+
+    return log_file_name, first_slurm_jobid
 
 def get_script_name(run_folder_name, script_name):
     
@@ -287,13 +362,31 @@ def mode_run_folder(folder_name, run_folder_name, source_file_path, local_projec
 
     # Creates folder if it does not exist and checks if the caspsule already exists.
     create_folder_and_check_if_experiment_exists(machine, pargs, folder_name, run_folder_name)
-    
 
-    # Copy the local version of pargs.target to the run_folder
-    machine.push(source_file_path, run_folder_name + "/", directory=True, copy_full_dir=False, verbose=True)
+    # create_folder_and_check_if_experiment_exists only mkdirs on the remote
+    # for SSH machines. Mirror it locally so subsequent local-filesystem
+    # operations (config writes, isdir asserts) succeed in -vm mode.
+    os.makedirs(run_folder_name, exist_ok=True)
 
-    # Patch settings with all .encap.conf files
-    settings.load_encap_config_files_recursive(os.path.join(os.getcwd(), run_folder_name))
+    # Copy the local version of pargs.target to the run_folder.
+    # Use rsync_push so that (a) rsync_exclude_push is honored, (b) only
+    # changed files cross the network on subsequent runs. Trailing "/" on
+    # source_file_path mirrors the previous `copy_full_dir=False` semantics
+    # (copy contents, not the source folder itself).
+    # -fp/--force-push: drop --update and add --ignore-times to transfer
+    # regardless of mtime/size comparison.
+    machine.rsync_push(source_file_path + "/", run_folder_name + "/",
+                       directory=True, verbose=True,
+                       last_timestamp_prevails=not pargs.force_push,
+                       ignore_times=pargs.force_push,
+                       ignore=["sending incremental", "sent ", "total size"])
+
+    # Patch settings with all .encap.conf files. Walk from the *source* folder:
+    # in -vm mode the run_folder only exists on the remote, so walking from
+    # the local mirror would miss any topic-level .encap.conf entirely. The
+    # source folder has the same configs (it's what was just pushed) and is
+    # guaranteed to exist locally.
+    settings.load_encap_config_files_recursive(os.path.join(os.getcwd(), source_file_path))
 
     # Infer the proper script_name
     if "script_name" in settings.config:
@@ -301,8 +394,10 @@ def mode_run_folder(folder_name, run_folder_name, source_file_path, local_projec
     else:
         # Defaul script name is run.*
         script_name = "run.*"
-    
-    script_name = get_script_name(run_folder_name, script_name)
+
+    # Glob against the source folder for the same reason as the config walk
+    # above: the run folder may only exist on the remote in -vm mode.
+    script_name = get_script_name(source_file_path, script_name)
 
     settings.config["script_name"] = script_name
     settings.args_config["script_name"] = script_name
@@ -370,24 +465,42 @@ def mode_rerun_file(run_folder_name, local_project_dir, machine, pargs, rerun=Tr
 
     if rerun:
         machine.sync_files()
-        machine.push(target_file_path, target_file_path, directory=False, verbose=True) # TODO: The entire folder should be pushed, not just the file.
-    
+        # rsync the whole experiment dir up, not just the entry script. The
+        # previous single-file push (with a `# TODO: The entire folder should
+        # be pushed, not just the file.` comment) meant that edits to helper
+        # modules (e.g. files imported by the entry script) inside the local
+        # experiment dir never reached the remote on `encap rerun`. rsync
+        # honors rsync_exclude_push, so outputs (*.hdf5, *.pdf, etc.) aren't
+        # shipped back up; stale log files might get pushed but get truncated
+        # by encap's wrapper at job start, so no harm done.
+        machine.rsync_push(run_folder_name + "/", run_folder_name + "/",
+                           directory=True, verbose=True,
+                           last_timestamp_prevails=not pargs.force_push,
+                           ignore_times=pargs.force_push,
+                           ignore=["sending incremental", "sent ", "total size"])
+
     # Are we using slurm?
     if not settings.using_slurm:
         if "i" in settings.config:
             number_of_instances = settings.config["i"]
         else:
             number_of_instances = 1
-        
+
         pid, log_file_name = run(machine, file_extension, args, run_folder_name=run_folder_name, target_file=target_file, target_file_path=target_file_path, number_of_instances=number_of_instances)
-    
+
     else:
 
         # Load the slurm settings from the loaded config file
         slurm_settings = slurm.read_slurm_settings_from_encapconfig(pargs.vm, local_project_dir)
-        
-        # Run the SLURM job with the slurm config file
-        log_file_name = run_slurm(machine, file_extension, pargs.target, args, run_folder_name=run_folder_name, target_file=target_file, target_file_path=target_file_path, slurm_settings=slurm_settings, name=pargs.name)
+
+        # Run the SLURM job with the slurm config file. run_slurm now also
+        # returns the first instance's slurm job id; encode as "slurm:<id>"
+        # so tail_pull polls squeue rather than relying solely on the EOT
+        # marker (which never arrives if the job is killed by slurm itself,
+        # OOMs, or hits a walltime cap).
+        log_file_name, slurm_jobid = run_slurm(machine, file_extension, pargs.target, args, run_folder_name=run_folder_name, target_file=target_file, target_file_path=target_file_path, slurm_settings=slurm_settings, name=pargs.name)
+        if slurm_jobid is not None:
+            pid = f"slurm:{slurm_jobid}"
 
     machine.pull(run_folder_name, run_folder_name, directory=True)
 
@@ -420,6 +533,9 @@ untar: Untars the experiment, if -n is not specified, all experiments are untarr
     parser.add_argument("-cn", "--copy-name", dest="copy_name", help="Name of the experiment to copy from.", required=False, default=None)
     parser.add_argument("-a", "--args", dest="args", help="Arguments for the interpreter, for example --args ' -k 5', forming `<interpreter> <file_name> <args>`.", default=None)
     parser.add_argument("-vm", "--vm_name", dest="vm", help="Name of the Virtual Machine (VM).", default=None)
+    parser.add_argument("-fp", "--force-push", dest="force_push",
+                        action="store_true", default=False,
+                        help="Force-push local files to the remote, ignoring rsync's mtime/size short-circuit (adds --ignore-times, drops --update). Use to recover from clock skew or other sync mysteries; rsync still uses delta-transfer so unchanged bytes don't go over the wire. Has no effect without -vm.")
     parser.add_argument("-sn", "--script_name", dest="script_name", help="Specify the script file to run when a folder is targeted. Default behavior is to find a file named `run.*`.", default=None)
     parser.add_argument("-i", "--number_of_instances", dest="i", help="Specify the number of instances to initiate concurrently. Each instance will have an associated environment variable, ENCAP_PROCID=<instance_number>. This option accepts either an integer, list or a Python expression in string format. When a list is provided, instances corresponding to the list items are initiated. Examples: -i '[0, 2, 3]' or -i 'range(5, 20)'. This feature is similar to -sl_i in Slurm mode.", default=None, type=eval)
     parser.add_argument("-int", "--interpreter", dest="interpreter", help="Specify the interpreter. If not provided, it's inferred from the file extension.", default=None)
@@ -536,23 +652,29 @@ def main():
         
         
     elif pargs.mode == "tail":
+        # ignore_errors=True so a missing pid file (slurm job that already
+        # finished, or a non-slurm experiment whose pid was cleaned up by a
+        # previous tail) doesn't raise inside run_code_local before we can
+        # decide what to do.
         code = f"cat {run_folder_name}/pid"
-        out = machine.run_code(code, verbose=False, output=True)
-        
-        assert len(out) == 1, out
-        if out[0].isdigit():
-            pid = out[0]
-            print("PID: ", pid)
+        out = machine.run_code(code, verbose=False, output=True, ignore_errors=True)
 
-            machine.pull(run_folder_name, run_folder_name, directory=True)
+        pid = None
+        if len(out) == 1:
+            content = out[0].strip()
+            if content.isdigit():
+                pid = content
+                print("PID: ", pid)
+            elif content.startswith("slurm:"):
+                pid = content
+                print("Slurm Job: ", content.split(":", 1)[1])
+            # else: cat error message ("cat: ...: No such file or directory"),
+            # or some other unexpected content -- treat as no tracked process.
 
-            tail_pull(machine, run_folder_name, pid)
+        machine.pull(run_folder_name, run_folder_name, directory=True)
+        tail_pull(machine, run_folder_name, pid)
+        if pid is not None:
             remove_process_from_database(pargs.target, pargs.name)
-
-        elif  out[0][:4] == "cat:":
-                machine.pull(run_folder_name, run_folder_name, directory=True)
-
-                machine.run_code(f"cat {run_folder_name}/log", verbose=True, output=True)
 
     elif pargs.mode == "copy":
         copy_folder_name = os.path.join(folder_name, pargs.copy_name)

--- a/encap_lib/encap_lib.py
+++ b/encap_lib/encap_lib.py
@@ -45,7 +45,8 @@ def get_machine(vm, local_project_dir):
         settings_project = settings.get_all_items(["projects", local_project_dir, "ssh", vm])
 
         ssh_kwargs = {}
-        copy_dict_keys = ["ssh_options", "ssh_ignore", "sync_files", "rsync_exclude", "sync"]
+        copy_dict_keys = ["ssh_options", "ssh_ignore", "sync_files", "rsync_exclude",
+                          "rsync_exclude_push", "rsync_exclude_pull", "sync"]
 
         for key in copy_dict_keys:
             if settings_project[key] is not None:

--- a/encap_lib/encap_settings.py
+++ b/encap_lib/encap_settings.py
@@ -116,7 +116,8 @@ config_file_name = os.path.join(config_folder, "config.yml")
 running_processes_file = os.path.join(home, ".encap", "running_processes.yml")
 
 config_items = ["dir", "ip", "sync", "user", "ssh_ignore", "ssh_options", "sync_files",
-                "rsync_exclude", "project", "zone", "nfs", "machine_config",
+                "rsync_exclude", "rsync_exclude_push", "rsync_exclude_pull",
+                "project", "zone", "nfs", "machine_config",
                 "GOOGLE_APPLICATION_CREDENTIALS", "machine_config", "slurm"]
 
 default_extensions = {"py": "python -u", "sh": "bash", "jl": "julia"}

--- a/encap_lib/machines.py
+++ b/encap_lib/machines.py
@@ -320,6 +320,26 @@ class LocalMachine(Machine):
             code = f"cp {recursiv} {self.local_project_dir}/{name_local} {self.local_project_dir}/{folder}"
             run_code_local(code, *args, **kwargs)
 
+    def rsync_push(self, name_local, name_target, directory=True,
+                   dry_run=False, last_timestamp_prevails=True,
+                   delete=False, ignore_times=False, *args, **kwargs):
+        """Local equivalent of SSHMachine.rsync_push.
+
+        For LocalMachine, source and target paths refer to the same
+        filesystem, so a 'push' is either a no-op (when source == target,
+        e.g. a local `encap rerun` where the experiment dir is already in
+        place) or a local `cp`. The rsync-only kwargs (dry_run,
+        last_timestamp_prevails, delete, ignore_times) have no analog for
+        cp and are accepted-and-ignored so callers can use a single API.
+        """
+        # rsync's trailing-slash-on-source means "copy contents, not the
+        # folder itself" -- map that to LocalMachine.push's copy_full_dir=False.
+        copy_full_dir = not name_local.endswith("/")
+        name_local = name_local.rstrip("/")
+        name_target = name_target.rstrip("/")
+        return self.push(name_local, name_target, directory=directory,
+                         copy_full_dir=copy_full_dir, *args, **kwargs)
+
     def pull(self, name_vm, name_local, directory=False, *args, **kwargs):
         pass
 

--- a/encap_lib/machines.py
+++ b/encap_lib/machines.py
@@ -89,7 +89,9 @@ class Machine:
 class SSHMachine(Machine):
 
     def __init__(self, ip, username, local_project_dir, remote_project_dir, ssh_options="",
-                ssh_ignore=[], sync_files=[], rsync_exclude=[], sync=True, **kwargs):
+                ssh_ignore=[], sync_files=[], rsync_exclude=[],
+                rsync_exclude_push=[], rsync_exclude_pull=[],
+                sync=True, **kwargs):
         super().__init__(**kwargs)
         self.ip = ip
         self.username = username
@@ -98,7 +100,16 @@ class SSHMachine(Machine):
         self.ssh_options = ssh_options
         self.ssh_ignore = ssh_ignore
         self._sync_files = sync_files
-        self.rsync_exclude = rsync_exclude
+        # Direction-specific exclude lists:
+        #   - rsync_exclude_push: patterns NOT shipped local->remote (e.g. local
+        #     caches, build artifacts you don't want on the cluster).
+        #   - rsync_exclude_pull: patterns NOT pulled remote->local (e.g.
+        #     cluster-only scratch dirs you don't want on disk locally).
+        # The legacy `rsync_exclude` key is treated as additive to push only
+        # (its original behavior, since pull was scp and ignored excludes).
+        # To exclude a pattern in both directions, list it in both new keys.
+        self.rsync_exclude_push = list(rsync_exclude) + list(rsync_exclude_push)
+        self.rsync_exclude_pull = list(rsync_exclude_pull)
         self.sync = sync
 
     @property
@@ -130,9 +141,18 @@ class SSHMachine(Machine):
         output = run_code_local(c, ignore=ignore, *args, **kwargs)
         return output
 
-    def push(self, name_local, name_target, directory=True, *args, **kwargs):
+    def push(self, name_local, name_target, directory=True, copy_full_dir=True, *args, **kwargs):
         # Upload file to VM
         if not self.sync and name_local == name_target:
+            return None
+
+        # "Self-push" (name_local == name_target) for which the local file
+        # doesn't exist is treated as a no-op: in folder-mode the source has
+        # already been pushed via the parent-dir rsync, so a redundant scp
+        # of a file that only exists on the remote would just fail.
+        if name_local == name_target and not os.path.exists(
+            os.path.join(self.local_project_dir, name_local)
+        ):
             return None
 
         i = name_target[::-1].find("/")
@@ -147,15 +167,26 @@ class SSHMachine(Machine):
 
         if directory:
             recursiv = "-r"
+            if not copy_full_dir:
+                # Copy *contents* of name_local into name_target rather than
+                # nesting the source folder inside it (mirrors LocalMachine.push).
+                name_local = name_local.rstrip("/") + "/."
         else:
             recursiv = ""
 
-        code = f"scp {self.ssh_options} {recursiv} {self.local_project_dir}/{name_local} {self.username}@{self.ip}:{self.remote_project_dir}/{folder}"
+        # -p preserves mtimes/modes so subsequent rsync quick-checks don't
+        # spuriously decide every file differs.
+        code = f"scp -p {self.ssh_options} {recursiv} {self.local_project_dir}/{name_local} {self.username}@{self.ip}:{self.remote_project_dir}/{folder}"
         return run_code_local(code, *args, **kwargs)
 
     def pull(self, file_name_vm, file_name_local, directory=False, *args, **kwargs):
-        # Download file from VM
-        #assert name_local != ""
+        # Download from VM via rsync.
+        # Benefits over scp: delta-transfer (only changed blocks fly),
+        # mtime preservation, better progress output, symmetric with rsync_push.
+        # The exclude list used here is `rsync_exclude_pull` -- distinct from
+        # `rsync_exclude_push` because the two directions usually have opposite
+        # intent (push wants to keep junk off the cluster, pull wants to bring
+        # back outputs that often match push-exclude patterns).
         if not self.sync and file_name_vm == file_name_local:
             return None
 
@@ -171,14 +202,35 @@ class SSHMachine(Machine):
             run_code_local(code, *args, **kwargs)
 
         if directory:
-            recursiv = "-r"
+            options = "-rz"
         else:
-            recursiv = ""
+            options = "-z"
 
-        code = f"scp {self.ssh_options} {recursiv} {self.username}@{self.ip}:{self.remote_project_dir}/{file_name_vm} {self.local_project_dir}/{folder}"
+        # --update protects local edits made while a -vm job is still running:
+        # if the user edited a local file after the push but before the
+        # post-run pull, rsync skips it (local mtime newer than the unchanged
+        # remote copy). New outputs written by the remote script always have
+        # later mtimes than anything local, so --update doesn't suppress them.
+        options = "--update " + options
+
+        for exclude in self.rsync_exclude_pull:
+            options = f"--exclude '{exclude}' " + options
+
+        default_ignore = self.ssh_ignore + [
+            "sending incremental", "receiving incremental",
+            "sent ", "total size",
+        ]
+        if "ignore" in kwargs:
+            kwargs["ignore"] = default_ignore + kwargs["ignore"]
+        else:
+            kwargs["ignore"] = default_ignore
+
+        code = f"""rsync {options} -v -e "ssh {self.ssh_options}" {self.username}@{self.ip}:{self.remote_project_dir}/{file_name_vm} {self.local_project_dir}/{folder}"""
         run_code_local(code, *args, **kwargs)
 
-    def rsync_push(self, name_local, name_target, directory=True, dry_run=False, last_timestamp_prevails=True, delete=False, *args, **kwargs):
+    def rsync_push(self, name_local, name_target, directory=True, dry_run=False,
+                   last_timestamp_prevails=True, delete=False, ignore_times=False,
+                   *args, **kwargs):
         # Upload file to VM
 
         i = name_target[::-1].find("/")
@@ -205,7 +257,13 @@ class SSHMachine(Machine):
         if delete:
             options = "--delete " + options
 
-        for exclude in self.rsync_exclude:
+        if ignore_times:
+            # Skip rsync's mtime/size short-circuit; transfer everything that
+            # would otherwise be quick-checked out. Used by encap's
+            # -fp/--force-push CLI flag.
+            options = "--ignore-times " + options
+
+        for exclude in self.rsync_exclude_push:
             options = f"--exclude '{exclude}' " + options
 
         code = f"""rsync {options} -v -e "ssh {self.ssh_options}" {self.local_project_dir}/{name_local} {self.username}@{self.ip}:{self.remote_project_dir}/{folder}"""


### PR DESCRIPTION
closes #2 

## Changes

### Make `-vm` folder mode work end-to-end
- `SSHMachine.push`: accept `copy_full_dir` kwarg and no-op when the local file of a "self-push" doesn't exist.
- `mode_run_folder`: create the local mirror dir; load `.encap.conf`s and resolve the entry script by walking the *source* folder (which exists locally) instead of the remote-only `run_folder`.
- Drop the redundant `target_file_path` self-pushes at the top of `run()` and `run_slurm()` — they're already redundant in every code path, and in `-vm` mode they overwrote the freshly-pushed remote file with the local mirror's stale copy.
- `SSHMachine.push` / `pull`: pass `-p` to `scp` so mtimes are preserved (later superseded by switching `pull` to rsync).

### Switch remote transfers to `rsync`
- `mode_run_folder` and `mode_rerun_file`'s rerun branch use `rsync_push` for the experiment-dir transfer instead of `scp`. Honors per-direction exclude lists, delta-transfers, preserves mtimes. The rerun branch now syncs the whole experiment dir (helpers included), not just the entry script — addresses the original `# TODO: The entire folder should be pushed` comment.
- `SSHMachine.pull` switched from `scp` to `rsync` for the same reasons.
- `LocalMachine.rsync_push` added as a thin wrapper around `push` (no-op for self-push, `cp` otherwise) so the same call sites work in local mode without `-vm`.

### Per-direction `rsync_exclude` config
The legacy `rsync_exclude` only meant "push direction" (pull was `scp`, which ignored it). Now there are explicit `rsync_exclude_push` and `rsync_exclude_pull` lists — push and pull usually have opposite intent (push wants to keep local junk off the cluster, pull wants to bring back outputs that often match push-exclude patterns like `*.hdf5`). The legacy `rsync_exclude` key is still accepted and treated as an alias for `rsync_exclude_push`.

### `-fp` / `--force-push`
New CLI flag that drops `--update` and adds `--ignore-times` on the rsync uploads. Escape hatch for clock-skew or other sync mysteries; rsync's delta-transfer still avoids unnecessary bytes on the wire.

### Slurm-aware `encap tail` + intermittent-hang fix
- `tail_pull`: when the EOT marker is read, explicitly `kill` the backgrounded `tail -f` (via PID captured from process substitution). Previously `tail` could outlive the bash script and keep the SSH session open, causing the terminal to hang until Ctrl-C if no extra log line followed the EOT.
- `tail -f -n +1` in the EOT branch so attaching to an already-finished log dumps the full content (matches the existing `--pid` branch behavior).
- Pid file format extended: `"<digits>"` for OS PIDs (legacy), `"slurm:<jobid>"` for Slurm jobs. `run_slurm` parses the Slurm job id from `sbatch`'s output and writes it to the `pid` file (it previously deleted the file and never wrote one).
- `tail_pull` gains a `slurm:` branch that streams the log and polls `squeue` — exits on either EOT (normal completion) or empty `squeue` (catches `scancel`, walltime cap, OOM).
- `tail` mode handler: `ignore_errors=True` on the `cat .../pid` call so a missing pid file (e.g. an already-finished experiment) falls through to the no-tracked-process path instead of raising.

### README
- Drop the "(untested with newest features)" caveat on the SSH section, mention rsync-based transfers and `-fp`.
- New "Following an Experiment with `encap tail`" section.
- Split the rsync-exclude docs into push/pull subsections (with a note that the legacy `rsync_exclude` key is still accepted).